### PR TITLE
Project update 1

### DIFF
--- a/data/rules/classic/specification.xml
+++ b/data/rules/classic/specification.xml
@@ -3365,9 +3365,9 @@
         </optionGroup>
         <optionGroup id="model.difficulty.natives" editable="false">
           <integerOption id="model.option.landPriceFactor"
-                         value="40"/>
+                         value="30"/>
           <integerOption id="model.option.nativeConvertProbability"
-                         value="50"/>
+                         value="70"/>
           <integerOption id="model.option.burnProbability"
                          value="2"/>
           <integerOption id="model.option.nativeDemands"
@@ -3484,9 +3484,9 @@
         </optionGroup>
         <optionGroup id="model.difficulty.government" editable="false">
           <integerOption id="model.option.badGovernmentLimit"
-                         value="8"/>
-          <integerOption id="model.option.veryBadGovernmentLimit"
                          value="12"/>
+          <integerOption id="model.option.veryBadGovernmentLimit"
+                         value="18"/>
           <integerOption id="model.option.goodGovernmentLimit"
                          value="50"/>
           <integerOption id="model.option.veryGoodGovernmentLimit"
@@ -3585,9 +3585,9 @@
           <integerOption id="model.option.taxAdjustment"
                          value="1"/>
           <integerOption id="model.option.mercenaryPrice"
-                         value="60"/>
+                         value="40"/>
           <integerOption id="model.option.maximumTax"
-                         value="60"/>
+                         value="40"/>
           <integerOption id="model.option.monarchSupport"
                          value="3"/>
           <integerOption id="model.option.treasureTransportFee"

--- a/freecol.iml
+++ b/freecol.iml
@@ -4,23 +4,9 @@
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/jars" type="java-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/test/lib" type="java-test-resource" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="module-library" scope="TEST">
-      <library name="JUnit4">
-        <CLASSES>
-          <root url="jar://$APPLICATION_HOME_DIR$/lib/junit-4.12.jar!/" />
-          <root url="jar://$APPLICATION_HOME_DIR$/lib/hamcrest-core-1.3.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES />
-      </library>
-    </orderEntry>
-    <orderEntry type="library" name="miglayout-core-4.2" level="application" />
-    <orderEntry type="library" name="commons-cli-1.3.1" level="project" />
+    <orderEntry type="library" name="jars1" level="project" />
   </component>
 </module>

--- a/src/net/sf/freecol/common/model/Monarch.java
+++ b/src/net/sf/freecol/common/model/Monarch.java
@@ -100,7 +100,7 @@ public final class Monarch extends FreeColGameObject implements Named {
     public static final int MONARCH_MINIMUM_PRICE = 200;
 
     /** The minimum price for a Hessian offer of mercenaries. */
-    public static final int HESSIAN_MINIMUM_PRICE = 5000;
+    public static final int HESSIAN_MINIMUM_PRICE = 4000;
 
     /**
      * The minimum tax rate (given in percentage) from where it

--- a/src/net/sf/freecol/common/model/SimpleCombatModel.java
+++ b/src/net/sf/freecol/common/model/SimpleCombatModel.java
@@ -654,7 +654,7 @@ public class SimpleCombatModel extends CombatModel {
                 // Good defences reduce this proportion.
                 double offencePower = getOffencePower(attacker, defender);
                 double defencePower = getDefencePower(attacker, defender);
-                double diff = Math.max(3.0, defencePower * 2.0 - offencePower);
+                double diff = Math.max(2.0, defencePower * 2.0 - offencePower);
                 great = r < odds.win / diff;
 
                 // Sink the defender on great wins or lack of repair

--- a/src/net/sf/freecol/server/ai/ColonyPlan.java
+++ b/src/net/sf/freecol/server/ai/ColonyPlan.java
@@ -514,13 +514,13 @@ public class ColonyPlan {
                 }
             }
             if (nationType.hasModifier(g.getId())) {
-                value = (value * 12) / 10; // Bonus for national advantages
+                value = (value * 14) / 10; // Bonus for national advantages
             }
             if (value > secondaryValue && secondaryRawMaterial != null) {
                 production.remove(secondaryRawMaterial);
                 production.remove(secondaryRawMaterial.getOutputType());
                 if (rawLuxuryGoodsTypes.remove(secondaryRawMaterial)) {
-                    ;//luxuryGoodsTypes.remove(secondaryRawMaterial.getOutputType());
+                    //luxuryGoodsTypes.remove(secondaryRawMaterial.getOutputType());
                 } else {
                     otherRawGoodsTypes.remove(secondaryRawMaterial);
                 }


### PR DESCRIPTION
Addressed 2 change requests from the official FreeCol request tracker here:
https://sourceforge.net/p/freecol/improvement-requests/

For #225: AI improvement – troops, colony location and taxes
Changes: Adjusted AI to more heavily favor trading resources which provide an advantage to the nation. (factor from 1.2 to 1.4)

#211: Three strikes to sink ships
Adjusted maximum probability threshold of sinking ships to 1/2 from 1/3. Addresses near-impossible victory requirements for late-game scenarios on very high difficulty.

Personal changes after playing the game:
There was a negligible difference between the "very easy" and "easy" difficulty modes. Maximum taxes were reduced to 75% of the next difficulty, the probability of favorable events such as native conversion and monarch support was increased by 20%, and the bad government threshold was doubled to be more forgiving of poor decisions for beginner players.